### PR TITLE
feat: :sparkles: add enharmonic button and its related functions

### DIFF
--- a/src/chordSheetsSettings.ts
+++ b/src/chordSheetsSettings.ts
@@ -10,6 +10,7 @@ export interface ChordSheetsSettings {
 	showChordOverview: ShowChordOverviewSetting;
 	showChordDiagramsOnHover: ShowChordDiagramsOnHoverSetting
 	showTransposeControl: boolean;
+    showHarmonicControl: boolean;
 	showInstrumentControl: boolean;
 	debug: boolean;
 	defaultInstrument: Instrument;
@@ -24,6 +25,7 @@ export const DEFAULT_SETTINGS: ChordSheetsSettings = {
 	showChordOverview: "always",
 	showChordDiagramsOnHover: "always",
 	showTransposeControl: true,
+    showHarmonicControl: true,
 	showInstrumentControl: true,
 	debug: false,
 	defaultInstrument: "guitar",

--- a/src/chordSheetsSettings.ts
+++ b/src/chordSheetsSettings.ts
@@ -10,7 +10,7 @@ export interface ChordSheetsSettings {
 	showChordOverview: ShowChordOverviewSetting;
 	showChordDiagramsOnHover: ShowChordDiagramsOnHoverSetting
 	showTransposeControl: boolean;
-    showHarmonicControl: boolean;
+    showEnharmonicControl: boolean;
 	showInstrumentControl: boolean;
 	debug: boolean;
 	defaultInstrument: Instrument;
@@ -25,7 +25,7 @@ export const DEFAULT_SETTINGS: ChordSheetsSettings = {
 	showChordOverview: "always",
 	showChordDiagramsOnHover: "always",
 	showTransposeControl: true,
-    showHarmonicControl: true,
+    showEnharmonicControl: true,
 	showInstrumentControl: true,
 	debug: false,
 	defaultInstrument: "guitar",

--- a/src/chordsUtils.ts
+++ b/src/chordsUtils.ts
@@ -102,6 +102,10 @@ export function transposeTonic(chordTonic: string, direction: "up" | "down") {
 	return direction === "up" ? Note.enharmonic(transposedTonic) : Note.simplify(transposedTonic);
 }
 
+export function enharmonicTonic(chordTonic: string) {
+	return Note.enharmonic(chordTonic);
+}
+
 export function findDbChord(chordToken: ChordToken, instrumentChords: InstrumentChords) {
 	const tonic = chordToken.chord.tonic;
 	const tonicVariations = getTonicVariations(tonic);

--- a/src/editor-extension/chordBlockToolsWidget.ts
+++ b/src/editor-extension/chordBlockToolsWidget.ts
@@ -13,6 +13,7 @@ export class ChordBlockToolsWidget extends WidgetType {
 	constructor(
 		private instrument: Instrument,
 		private showTransposeControl: boolean,
+        private showEnharmonicControl: boolean,
 		private showInstrumentControl: boolean,
 		private chordOverviewVisible: boolean
 	) {
@@ -26,6 +27,7 @@ export class ChordBlockToolsWidget extends WidgetType {
 	eq(other: ChordBlockToolsWidget) {
 		return this.instrument === other.instrument
 			&& this.showTransposeControl === other.showTransposeControl
+            && this.showEnharmonicControl === other.showEnharmonicControl
 			&& this.showInstrumentControl === other.showInstrumentControl
 			&& this.chordOverviewVisible === other.chordOverviewVisible;
 	}
@@ -58,6 +60,13 @@ export class ChordBlockToolsWidget extends WidgetType {
 			instrumentSelect && instrumentSelect.remove();
 		}
 
+        const enharmonicButton = this.getEnharmonicButton(dom);
+		if (this.showEnharmonicControl) {
+			!enharmonicButton && this.createEnharmonicButton(dom);
+		} else {
+			enharmonicButton?.remove();
+		}
+
 		return true;
 	}
 
@@ -74,6 +83,9 @@ export class ChordBlockToolsWidget extends WidgetType {
 
 		if (this.showTransposeControl) {
 			this.createTransposeControl(containerEl);
+		}
+        if (this.showEnharmonicControl) {
+			this.createEnharmonicButton(containerEl);
 		}
 
 		if (this.showInstrumentControl) {
@@ -136,11 +148,24 @@ export class ChordBlockToolsWidget extends WidgetType {
 		containerEl.firstElementChild?.prepend(el);
 	}
 
+    private createEnharmonicButton(containerEl: HTMLElement): void {
+		const el = Object.assign(document.createElement("button"), {
+			className: 'chord-sheet-enharmonic',
+            textContent: 'Enharmonic'
+		});
+
+		containerEl.firstElementChild?.prepend(el);
+	}
+
 	private getInstrumentSelect(el: HTMLElement): HTMLSelectElement | null {
 		return el.querySelector("select");
 	}
 
 	private getTransposeControl(el: HTMLElement): HTMLSelectElement | null {
 		return el.querySelector(".chord-sheet-transpose-control");
+	}
+
+    private getEnharmonicButton(el: HTMLElement): HTMLSelectElement | null {
+		return el.querySelector(".chord-sheet-enharmonic");
 	}
 }

--- a/src/editor-extension/chordBlocksStateField.ts
+++ b/src/editor-extension/chordBlocksStateField.ts
@@ -395,9 +395,9 @@ function getChordBlockDecos(config: ChordSheetsSettings, chordBlockRanges: Range
 				side: -1
 			}));
 
-			if (config.showTransposeControl || config.showInstrumentControl) {
+			if (config.showTransposeControl || config.showInstrumentControl || config.showHarmonicControl) {
 				builder.add(chordBlockIter.from, chordBlockIter.from, Decoration.widget({
-					widget: new ChordBlockToolsWidget(chordBlockIter.value.instrument, config.showTransposeControl, config.showInstrumentControl, shouldShowChordOverviewInEditor(config)),
+					widget: new ChordBlockToolsWidget(chordBlockIter.value.instrument, config.showTransposeControl, config.showInstrumentControl,config.showHarmonicControl, shouldShowChordOverviewInEditor(config)),
 					side: 0,
 					block: false
 				}));

--- a/src/editor-extension/chordBlocksStateField.ts
+++ b/src/editor-extension/chordBlocksStateField.ts
@@ -395,9 +395,9 @@ function getChordBlockDecos(config: ChordSheetsSettings, chordBlockRanges: Range
 				side: -1
 			}));
 
-			if (config.showTransposeControl || config.showInstrumentControl || config.showHarmonicControl) {
+			if (config.showTransposeControl || config.showInstrumentControl || config.showEnharmonicControl) {
 				builder.add(chordBlockIter.from, chordBlockIter.from, Decoration.widget({
-					widget: new ChordBlockToolsWidget(chordBlockIter.value.instrument, config.showTransposeControl, config.showInstrumentControl,config.showHarmonicControl, shouldShowChordOverviewInEditor(config)),
+					widget: new ChordBlockToolsWidget(chordBlockIter.value.instrument, config.showTransposeControl, config.showInstrumentControl,config.showEnharmonicControl, shouldShowChordOverviewInEditor(config)),
 					side: 0,
 					block: false
 				}));

--- a/src/editor-extension/chordSheetsViewPlugin.ts
+++ b/src/editor-extension/chordSheetsViewPlugin.ts
@@ -23,6 +23,14 @@ export interface TransposeEventDetail {
 	}
 }
 
+export interface EnharmonicEventDetail {
+	blockDef: {
+		from: number
+		to: number
+		value: IChordBlockRangeValue
+	}
+}
+
 export const chordSheetEditorPlugin = () => ViewPlugin.fromClass(ChordSheetsViewPlugin, {
 	eventHandlers: {
 		click: function (event: MouseEvent, view: EditorView) {
@@ -45,8 +53,25 @@ export const chordSheetEditorPlugin = () => ViewPlugin.fromClass(ChordSheetsView
 					});
 					window.dispatchEvent(transposeEvent);
 				}
+			} else if (target.nodeName === "BUTTON" && target.classList.contains("chord-sheet-enharmonic")) {
+				event.stopPropagation();
+				const pos = view.posAtDOM(target);
+				const chordBlockRange = view.state.field(chordBlocksStateField).ranges.iter(pos);
+				if (chordBlockRange.value) {
+					const enharmonicEvent = new CustomEvent<EnharmonicEventDetail>('chord-sheet-enharmonic', {
+						detail: {
+							blockDef: {
+								from: chordBlockRange.from,
+								to: chordBlockRange.to,
+								value: chordBlockRange.value
+							}
+						}
+					});
+					window.dispatchEvent(enharmonicEvent);
+				}
 			}
 		},
+        
 		mousemove: function (event: MouseEvent, view: EditorView) {
 			const {showChordDiagramsOnHover} = view.state.facet(chordSheetsConfigFacet);
 			if (

--- a/styles.css
+++ b/styles.css
@@ -190,6 +190,12 @@ pre.chord-sheet-chord-block-preview {
 	color: var(--text-muted);
 }
 
+.chord-sheet-enharmonic {
+	border-radius: var(--button-radius);
+	box-shadow: none;
+    margin-right: 6px;
+}
+
 /* Autoscroll controls */
 .chord-sheet-autoscroll-control {
 	display: flex;

--- a/types/chord-sheet-events.d.ts
+++ b/types/chord-sheet-events.d.ts
@@ -1,5 +1,5 @@
 import {InstrumentChangeEventDetail} from "../src/editor-extension/chordBlockToolsWidget";
-import {TransposeEventDetail} from "../src/editor-extension/chordSheetsViewPlugin";
+import {TransposeEventDetail, EnharmonicEventDetail} from "../src/editor-extension/chordSheetsViewPlugin";
 
 declare global {
 
@@ -7,5 +7,6 @@ declare global {
 	interface WindowEventMap {
 		"chord-sheet-instrument-change": CustomEvent<InstrumentChangeEventDetail>;
 		"chord-sheet-transpose": CustomEvent<TransposeEventDetail>;
+        "chord-sheet-enharmonic": CustomEvent<EnharmonicEventDetail>;
 	}
 }


### PR DESCRIPTION
This adds another button to automatically enharmonic all chords. 

I've been using this plugin and the transpose function is really helpful. Sadly, it only transposes any Chord into # (sharp). I thought this button would be useful to also transpose the chords to any b (flat) scales.

There can also be a variation to this, a button like "Enharmonic into [#] [b]". Adds a little bit of complexity but it can standardize chords to use the same notations. 

For now, this should suffice. What do you think?

![enharmonic-example](https://github.com/olvidalo/obsidian-chord-sheets/assets/46718606/998b0c38-ec17-45cf-8f39-5963fdebb53d)
