### PR TITLE
User-defined chords support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ rendered locally, no API calls to an external service required.
 
 ![chord-overview.gif](docs/chord-overview.gif)
 
+### 🔨 Custom Chord Shapes
+
+Define your own chord shapes using brackets: `Bbadd13[x13333]`, `Dm6[4|x2x132]` (with capo), or `C°[x34_242_]`
+(with barre).
+
 ### 🎸 Choose Your Instrument
 
 Includes chord diagrams for guitar, ukulele and mandolin. The instrument can be set globally or specified per chord block.

--- a/src/chordsUtils.ts
+++ b/src/chordsUtils.ts
@@ -109,6 +109,7 @@ export function tokenizeLine(line: string, lineIndex: number, chordLineMarker: s
 	let wordTokenCount: number = 0;
 	let markerValue: MarkerToken['value'] | null = null;
 	let headerToken: HeaderToken | null = null;
+	let hasUserDefinedChord = false;
 
 	let match: RegExpExecArray | null;
 	while ((match = tokenPattern.exec(line)) !== null) {
@@ -178,6 +179,7 @@ export function tokenizeLine(line: string, lineIndex: number, chordLineMarker: s
 				chordSymbolIndex: [chordSymbolIndex[0], chordSymbolIndex[0] + chord_name.length],
 			};
 			tokens.push(chordToken);
+			hasUserDefinedChord = true;
 
 		} else if (groups.inline_chord) {
 			const {7: startTag, 8: chordSymbol, 9: auxText, 10: endTag} = match;
@@ -231,7 +233,7 @@ export function tokenizeLine(line: string, lineIndex: number, chordLineMarker: s
 		? true
 		: markerValue === textLineMarker
 			? false
-			: possibleChordOrRhythmTokens.size / wordTokenCount > 0.5;
+			: hasUserDefinedChord || possibleChordOrRhythmTokens.size / wordTokenCount > 0.5;
 
 	if (isChordLine) {
 		for (const [token, tokenInfo] of possibleChordOrRhythmTokens) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -290,18 +290,20 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 	private transpose(chordRanges: ChordRange[], editor: EditorView, direction: "up" | "down") {
 		const changes: ChangeSpec[] = [];
 		for (const chordRange of chordRanges) {
-			const { from, to, value } = chordRange;
-			const [chordTonic, chordType, bassNote] = Chord.tokenize(value);
-			const simplifiedTonic = transposeTonic(chordTonic, direction);
+			if (chordRange.chord.userDefinedChord === undefined) {
+				const {from, to, value} = chordRange;
+				const [chordTonic, chordType, bassNote] = Chord.tokenize(value);
+				const simplifiedTonic = transposeTonic(chordTonic, direction);
 
-			let transposedChord;
-			if (bassNote) {
-				transposedChord = simplifiedTonic + chordType + "/" + transposeTonic(bassNote, direction);
-			} else {
-				transposedChord = simplifiedTonic + (chordType ?? "");
+				let transposedChord;
+				if (bassNote) {
+					transposedChord = simplifiedTonic + chordType + "/" + transposeTonic(bassNote, direction);
+				} else {
+					transposedChord = simplifiedTonic + (chordType ?? "");
+				}
+
+				changes.push({from, to, insert: transposedChord});
 			}
-
-			changes.push({from, to, insert: transposedChord});
 		}
 		editor.plugin(this.editorPlugin)?.applyChanges(changes);
 	}


### PR DESCRIPTION
This patch adds support for special chords, defined by the user.

Example syntax:

# Special chord:
Bbadd13[x13333]

# With capo at 4
Dm6[4|x2x132]

# With barre
C°[x34_242_]

Notes:
- Transpose has no effect on user defined chords
- Once a chord is defined, let's say Bbadd13[x13333], it can be referred by its name only (Bbadd13)

Hope you find this patch useful and thanks again for your plugin!