### PR TITLE
Autoscroll visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Příkazy
+
+```bash
+npm run build    # TypeScript check + produkční build (main.js)
+npm run dev      # Vývojový režim – sleduje změny
+npm run deploy   # build + zkopíruje do Obsidianu
+npm test         # Spustí Jest testy
+```
+
+Po každém buildu je nutné plugin v Obsidianu **vypnout a znovu zapnout**.
+
+## Kontext repozitáře
+
+Toto je **fork** původního pluginu [`olvidalo/obsidian-chord-sheets`](https://github.com/olvidalo/obsidian-chord-sheets).
+- `origin` → `pavdi7/obsidian-chord-sheets` (náš fork)
+- `upstream` → `olvidalo/obsidian-chord-sheets` (originál)
+
+Aktivní vývojová větev: `Autoscroll_visibility`.
+
+## Architektura
+
+Plugin renderuje **akordy nad textem** (formát ```` ```chords ```` blok nebo inline závorky) v Obsidianu. Klíčový aspekt: rendering v editačním/live preview módu je implementován jako **CodeMirror 6 editor extension** (ne jako Markdown post-processor), což umožňuje editaci bez přepínání do source view.
+
+### Tok renderingu
+
+```
+Obsidian editor (CodeMirror 6)
+  └─► chordSheetsEditorExtension   – registrace CM extension
+        └─► chordSheetsViewPlugin  – ViewPlugin: sleduje změny dokumentu
+              └─► chordBlocksStateField – StateField: parsuje chord bloky
+                    └─► sheet-parsing/tokenizeLine  – tokenizace řádků na akordy/texty
+              └─► chordBlockToolsWidget  – UI: transpose, nástroj, autoscroll
+              └─► chordOverviewWidget    – přehled diagramů nad blokem
+              └─► chordTooltip          – tooltip s diagramem při hover
+
+Obsidian reading mode
+  └─► chordBlockPostProcessorView   – Markdown post-processor (čtecí mód)
+```
+
+### Klíčové soubory v `src/`
+
+| Soubor / složka | Účel |
+|---|---|
+| `main.ts` | Hlavní plugin: registrace extension, příkazů, settings |
+| `editor-extension/` | Vše pro CodeMirror 6 live preview mód |
+| `sheet-parsing/tokenizeLine.ts` | Parsování řádku na tokeny (akord vs. text vs. sekce) |
+| `sheet-parsing/tokens.ts` | Typy tokenů |
+| `chordProcessing.ts` | Logika detekce, transpozice a normalizace akordů (využívá `tonal`) |
+| `chordDiagrams.ts` | Rendering diagramů (využívá `vexchords` a `chords-db`) |
+| `chordSheetsSettings.ts` | Datová struktura nastavení |
+| `chordSheetsSettingTab.ts` | UI nastavení pluginu |
+| `autoscrollControl.ts` | Logika autoscrollu a ukládání rychlosti do frontmatter |
+| `customChordTypes.ts` | Parsování vlastních tvarů akordů ve formátu `Bbadd13[x13333]` |
+
+### Klíčové závislosti
+
+- **`tonal`** — parsování a transpozice akordů
+- **`@chordbook/charts`** (vexchords) — SVG rendering diagramů
+- **`@tombatossals/chords-db`** — databáze prstokladů pro kytaru/ukulele/mandolínu
+- **`tippy.js`** — tooltip pro hover diagramy

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"deploy": "npm run build && cp main.js manifest.json '/home/dittmer/Dokumenty/Obsidian/.obsidian_pavel/plugins/chord-sheets/'",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"test": "jest"
 	},

--- a/src/autoscrollControl.ts
+++ b/src/autoscrollControl.ts
@@ -49,7 +49,10 @@ export class AutoscrollControl extends Component {
 		super.onunload();
 	}
 
-	start() {
+	showControl() {
+		if (this.controlEl) {
+			return; // Already shown
+		}
 		this.controlEl = this.view.contentEl.createDiv({
 			prepend: true,
 			text: "Autoscroll speed",
@@ -62,17 +65,24 @@ export class AutoscrollControl extends Component {
 			.onChange(value => {
 				this.speed = value;
 			});
+	}
 
+	hideControl() {
+		if (this.controlEl) {
+			this.controlEl.remove();
+			this.controlEl = null;
+			this.slider = null;
+		}
+	}
+
+	start() {
+		this.showControl();
 		this.startInterval();
 	}
 
 	stop() {
 		this.stopInterval();
-
-		if (this.controlEl) {
-			this.controlEl.remove();
-			this.controlEl = null;
-		}
+		this.hideControl();
 	}
 
 	increaseSpeed() {

--- a/src/chordSheetsSettingTab.ts
+++ b/src/chordSheetsSettingTab.ts
@@ -7,6 +7,7 @@ import {
 	DEFAULT_CHORD_LINE_MARKER,
 	DEFAULT_TEXT_LINE_MARKER,
 	ShowAutoscrollButtonSetting,
+	ShowAutoscrollSpeedSetting,
 	ShowChordDiagramsOnHoverSetting,
 	ShowChordOverviewSetting
 } from "./chordSheetsSettings";
@@ -239,6 +240,24 @@ export class ChordSheetsSettingTab extends PluginSettingTab {
 				.onChange(async value => {
 					this.plugin.settings.alwaysSaveAutoscrollSpeedToFrontmatter = value;
 					await this.plugin.saveSettings();
+				})
+			);
+
+		const showAutoscrollSpeedOptions: Record<ShowAutoscrollSpeedSetting, string> = {
+			edit: "In edit mode",
+			always: "Always",
+			"on-autoscroll": "On autoscroll"
+		};
+		new Setting(containerEl)
+			.setName('Show autoscroll speed control')
+			.setDesc('Control the visibility of the autoscroll speed slider.')
+			.addDropdown(dropdown => dropdown
+				.addOptions(showAutoscrollSpeedOptions)
+				.setValue(this.plugin.settings.showAutoscrollSpeed)
+				.onChange(async (value: ShowAutoscrollSpeedSetting) => {
+					this.plugin.settings.showAutoscrollSpeed = value;
+					await this.plugin.saveSettings();
+					this.plugin.applyNewSettingsToEditors();
 				})
 			);
 

--- a/src/chordSheetsSettingTab.ts
+++ b/src/chordSheetsSettingTab.ts
@@ -261,6 +261,18 @@ export class ChordSheetsSettingTab extends PluginSettingTab {
 				})
 			);
 
+		new Setting(containerEl)
+			.setName('Show autoscroll speed control on chord block')
+			.setDesc('If enabled, the autoscroll speed control will only be shown on notes containing chord blocks. If disabled, it will be shown on all notes according to the "Show autoscroll speed control" setting.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.showAutoscrollSpeedOnChordBlocksOnly)
+				.onChange(async (value) => {
+					this.plugin.settings.showAutoscrollSpeedOnChordBlocksOnly = value;
+					await this.plugin.saveSettings();
+					this.plugin.applyNewSettingsToEditors();
+				})
+			);
+
 		const showAutoscrollButtonOptions: Record<ShowAutoscrollButtonSetting, string> = {
 			never: "Never",
 			"chord-blocks": "When note has chord blocks",

--- a/src/chordSheetsSettings.ts
+++ b/src/chordSheetsSettings.ts
@@ -21,6 +21,7 @@ export interface ChordSheetsSettings {
 	autoscrollDefaultSpeed: number;
 	showAutoscrollButton: ShowAutoscrollButtonSetting;
 	showAutoscrollSpeed: ShowAutoscrollSpeedSetting;
+	showAutoscrollSpeedOnChordBlocksOnly: boolean;
 	blockLanguageSpecifier: string;
 	alwaysSaveAutoscrollSpeedToFrontmatter: boolean;
 	chordLineMarker: string;
@@ -43,6 +44,7 @@ export const DEFAULT_SETTINGS: ChordSheetsSettings = {
 	autoscrollDefaultSpeed: 10,
 	showAutoscrollButton: "chord-blocks",
 	showAutoscrollSpeed: "on-autoscroll",
+	showAutoscrollSpeedOnChordBlocksOnly: true,
 	blockLanguageSpecifier: DEFAULT_BLOCK_LANGUAGE_SPECIFIER,
 	alwaysSaveAutoscrollSpeedToFrontmatter: false,
 	chordLineMarker: DEFAULT_CHORD_LINE_MARKER,

--- a/src/chordSheetsSettings.ts
+++ b/src/chordSheetsSettings.ts
@@ -1,6 +1,7 @@
 import {Instrument} from "./chordsUtils";
 
 export type ShowAutoscrollButtonSetting = "never" | "chord-blocks" | "always";
+export type ShowAutoscrollSpeedSetting = "edit" | "always" | "on-autoscroll";
 export type ShowChordOverviewSetting = "never" | "edit" | "preview" | "always";
 export type ShowChordDiagramsOnHoverSetting = "never" | "edit" | "preview" | "always";
 
@@ -19,6 +20,7 @@ export interface ChordSheetsSettings {
 	diagramWidth: number;
 	autoscrollDefaultSpeed: number;
 	showAutoscrollButton: ShowAutoscrollButtonSetting;
+	showAutoscrollSpeed: ShowAutoscrollSpeedSetting;
 	blockLanguageSpecifier: string;
 	alwaysSaveAutoscrollSpeedToFrontmatter: boolean;
 	chordLineMarker: string;
@@ -40,6 +42,7 @@ export const DEFAULT_SETTINGS: ChordSheetsSettings = {
 	diagramWidth: 100,
 	autoscrollDefaultSpeed: 10,
 	showAutoscrollButton: "chord-blocks",
+	showAutoscrollSpeed: "on-autoscroll",
 	blockLanguageSpecifier: DEFAULT_BLOCK_LANGUAGE_SPECIFIER,
 	alwaysSaveAutoscrollSpeedToFrontmatter: false,
 	chordLineMarker: DEFAULT_CHORD_LINE_MARKER,

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,18 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 			})
 		);
 
+		// Handle mode changes (edit/reading mode)
+		this.registerEvent(
+			this.app.workspace.on("layout-change", () => {
+				this.app.workspace.iterateAllLeaves(leaf => {
+					if (leaf.view.getViewType() === "markdown") {
+						const markdownView = leaf.view as MarkdownView;
+						this.updateAutoscrollSpeedControl(markdownView);
+					}
+				});
+			})
+		);
+
 
 		// Register editor commands
 
@@ -390,6 +402,67 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 			} else if (existingEl) {
 				existingEl.remove();
 			}
+
+			// Update autoscroll speed control visibility
+			this.updateAutoscrollSpeedControl(view);
+		}
+	}
+
+	private updateAutoscrollSpeedControl(view: MarkdownView) {
+		let autoscrollControl = this.viewAutoscrollControlMap.get(view);
+
+		if (this.settings.showAutoscrollSpeed === "edit") {
+			// Show control only in edit mode (source mode)
+			if (view.getMode() === "source") {
+				// Ensure control exists and is shown
+				if (!autoscrollControl) {
+					const frontmatterSpeed = this.getAutoscrollSpeedFromFrontmatter(view.file);
+					const speed = frontmatterSpeed ?? this.settings.autoscrollDefaultSpeed;
+					autoscrollControl = new AutoscrollControl(view, speed);
+					this.registerEvent(autoscrollControl.events.on(SPEED_CHANGED_EVENT, (newSpeed: number) => {
+						const file = view.file;
+						if (!file) {
+							return;
+						}
+						const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+						const isSpeedInFrontmatter = frontmatter && AUTOSCROLL_SPEED_PROPERTY in frontmatter;
+						if (this.settings.alwaysSaveAutoscrollSpeedToFrontmatter || isSpeedInFrontmatter) {
+							this.saveAutoscrollSpeed(file, newSpeed);
+						}
+					}));
+					this.viewAutoscrollControlMap.set(view, autoscrollControl);
+				}
+				autoscrollControl.showControl();
+			} else {
+				// Hide control in reading mode (preview mode)
+				autoscrollControl?.hideControl();
+			}
+		} else if (this.settings.showAutoscrollSpeed === "always") {
+			// Ensure control exists and is shown
+			if (!autoscrollControl) {
+				const frontmatterSpeed = this.getAutoscrollSpeedFromFrontmatter(view.file);
+				const speed = frontmatterSpeed ?? this.settings.autoscrollDefaultSpeed;
+				autoscrollControl = new AutoscrollControl(view, speed);
+				this.registerEvent(autoscrollControl.events.on(SPEED_CHANGED_EVENT, (newSpeed: number) => {
+					const file = view.file;
+					if (!file) {
+						return;
+					}
+					const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+					const isSpeedInFrontmatter = frontmatter && AUTOSCROLL_SPEED_PROPERTY in frontmatter;
+					if (this.settings.alwaysSaveAutoscrollSpeedToFrontmatter || isSpeedInFrontmatter) {
+						this.saveAutoscrollSpeed(file, newSpeed);
+					}
+				}));
+				this.viewAutoscrollControlMap.set(view, autoscrollControl);
+			}
+			autoscrollControl.showControl();
+		} else if (this.settings.showAutoscrollSpeed === "on-autoscroll") {
+			// For "on-autoscroll", the control visibility is handled by start/stop methods
+			// If not running, hide it
+			if (!autoscrollControl?.isRunning) {
+				autoscrollControl?.hideControl();
+			}
 		}
 	}
 
@@ -468,6 +541,8 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 				markdownView.previewMode?.rerender(true);
 				const chordPlugin = editorView?.plugin(this.editorPlugin);
 				chordPlugin?.updateSettings(this.settings);
+				// Update autoscroll controls when settings change
+				this.updateAutoscrollSpeedControl(markdownView);
 			}
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -409,6 +409,16 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 	}
 
 	private updateAutoscrollSpeedControl(view: MarkdownView) {
+		if (this.settings.showAutoscrollSpeedOnChordBlocksOnly) {
+			const editorView = view.editor.cm as EditorView;
+			const plugin = editorView.plugin(this.editorPlugin);
+			if (!plugin?.hasChordBlocks()) {
+				const autoscrollControl = this.viewAutoscrollControlMap.get(view);
+				autoscrollControl?.hideControl();
+				return;
+			}
+		}
+
 		let autoscrollControl = this.viewAutoscrollControlMap.get(view);
 
 		if (this.settings.showAutoscrollSpeed === "edit") {


### PR DESCRIPTION
Hi, I created this PR, which solves a problem I had when using autoscroll. I use a footswitch to start autoscroll, so I don't have to set the speed precisely for each song. Basically, when I get to the end of the visible text, I press the footswitch to start autoscroll, and when the text has scrolled far enough, I press the footswitch again to stop it. In the current version, however, this means that when the autoscroll-speed control appears, the text moves down one line (the line is taken up by the control), and when I stop autoscroll, the line with the control disappears again, causing the text to jump around and making it difficult to follow. 

My PR solves this. The settings now include the option "Show autoscroll control" and three options:
- In edit mode
- On autoscroll
- Always

On autoscroll is the default value and works the same as today. Always means that it is always visible in reading and editing mode (even when not running). In edit mode means that it is never visible in reading mode and always visible in edit mode.

I'm not a developer, it's just a little hobby with the help of AI, but if you find the PR useful, I'd be happy if you added it to your add-on.

Finally, I would like to thank you for the great add-on, which has helped me a lot. 

I created an index page in Obsidian using JS, which is used to filter authors and songs. I am attaching a screenshot. I was wondering if it would be possible and, above all, desirable to incorporate something like this into your add-on. If you are interested, please let me know.

<img width="1223" height="854" alt="zpevnik" src="https://github.com/user-attachments/assets/8a6dadc7-9f66-4039-af6c-3876b27a7154" />
