### PR TITLE
feat: add piano instrument support

### DIFF
--- a/src/chordBlockPostProcessorView.ts
+++ b/src/chordBlockPostProcessorView.ts
@@ -224,7 +224,12 @@ export class ChordBlockPostProcessorView extends MarkdownRenderChild {
 				return {popper};
 			},
 			onShow(instance) {
-				instance.popper.appendChild(makeChordDiagram(instrument, token, diagramWidth));
+				const chordBox = makeChordDiagram(instrument, token, diagramWidth, 0, false);
+				if (chordBox) {
+					instance.popper.appendChild(chordBox);
+				} else {
+					return false;
+				}
 			},
 			onHidden(instance) {
 				instance.popper.empty();

--- a/src/chordDiagrams.ts
+++ b/src/chordDiagrams.ts
@@ -2,6 +2,7 @@ import {chordSequenceString, findDbChord, Instrument, UserDefinedChord} from "./
 import {ChordBox} from "@chordbook/charts";
 import ChordsDB, {ChordDef} from "@tombatossals/chords-db";
 import {ChordToken} from "./sheet-parsing/tokens";
+import {makePianoChordDiagram} from "./pianoChordRenderer";
 
 type ChordBoxParams = Parameters<ChordBox["draw"]>[0];
 
@@ -208,7 +209,11 @@ function updateChordPosition(containerEl: HTMLElement, numPositions: number, pos
 	}
 }
 
-export function makeChordDiagram(instrument: Instrument, chordToken: ChordToken, width = 100, position = 0) {
+export function makeChordDiagram(instrument: Instrument, chordToken: ChordToken, width = 100, position = 0, showControls = true) {
+	if (instrument === "piano") {
+		return makePianoChordDiagram(chordToken, width, showControls);
+	}
+
 	const containerEl = document.createElement("div");
 	containerEl.addClass("chord-sheet-chord-diagram");
 	const chordBox: HTMLDivElement = document.createElement('div');
@@ -329,7 +334,10 @@ export function makeChordDiagram(instrument: Instrument, chordToken: ChordToken,
 
 export function makeChordOverview(instrument: Instrument, container: HTMLElement, chordTokens: ChordToken[], width?: number) {
 	for (const chordToken of chordTokens) {
-		container.appendChild(makeChordDiagram(instrument, chordToken, width));
+		const chordBox = makeChordDiagram(instrument, chordToken, width);
+		if (chordBox) {
+			container.appendChild(chordBox);
+		}
 	}
 	container.dataset.chordSequence = chordSequenceString(chordTokens);
 	container.dataset.instrument = instrument;

--- a/src/chordSheetsSettingTab.ts
+++ b/src/chordSheetsSettingTab.ts
@@ -93,6 +93,7 @@ export class ChordSheetsSettingTab extends PluginSettingTab {
 				.addOption("ukulele-d-tuning", "Ukulele (D tuning)")
 				.addOption("ukulele-baritone", "Ukulele (Baritone)")
 				.addOption("mandolin", "Mandolin")
+				.addOption("piano", "Piano")
 				.setValue(this.plugin.settings.defaultInstrument)
 				.onChange(async (value: Instrument) => {
 					this.plugin.settings.defaultInstrument = value;

--- a/src/chordsUtils.ts
+++ b/src/chordsUtils.ts
@@ -3,7 +3,7 @@ import {ChordDef, IChordsDB, InstrumentChords} from "@tombatossals/chords-db";
 
 import {ChordToken} from "./sheet-parsing/tokens";
 
-export type Instrument = keyof IChordsDB;
+export type Instrument = keyof IChordsDB | "piano";
 
 
 export interface UserDefinedChord {

--- a/src/editor-extension/chordBlockToolsWidget.ts
+++ b/src/editor-extension/chordBlockToolsWidget.ts
@@ -110,6 +110,7 @@ export class ChordBlockToolsWidget extends WidgetType {
 		el.append(instrumentOption("guitar", "Guitar"));
 		el.append(instrumentOption("ukulele", "Ukulele"));
 		el.append(instrumentOption("mandolin", "Mandolin"));
+		el.append(instrumentOption("piano", "Piano"));
 
 
 		el.append(document.createElement("hr"));

--- a/src/editor-extension/chordBlocksStateField.ts
+++ b/src/editor-extension/chordBlocksStateField.ts
@@ -470,7 +470,7 @@ function parseChordBlocks(state: EditorState, from: number, to: number, parseCho
 					const chordBlockStartMatch = line.text.match(`^(?:~{3,}|\`{3,})(${settings.blockLanguageSpecifier})\\b-?(.*)`);
 					if (chordBlockStartMatch) {
 						if (chordBlockStartMatch[2]) {
-							if (!Object.keys(ChordsDB).includes(chordBlockStartMatch[2])) {
+							if (!Object.keys(ChordsDB).includes(chordBlockStartMatch[2]) && chordBlockStartMatch[2] !== "piano") {
 								console.error(`Unknown instrument: ${chordBlockStartMatch[2]}`);
 								return false;
 							}

--- a/src/editor-extension/chordTooltip.ts
+++ b/src/editor-extension/chordTooltip.ts
@@ -23,8 +23,12 @@ export class ChordTooltip {
 		});
 	}
 
-	show(target: HTMLElement, instrument: Instrument, chordToken: ChordToken, diagramWidth: number): void { // Replace `any` with the correct type for `vexChord`
-		this.popper.appendChild(makeChordDiagram(instrument, chordToken, diagramWidth));
+	show(target: HTMLElement, instrument: Instrument, chordToken: ChordToken, diagramWidth: number): void {
+		const chordBox = makeChordDiagram(instrument, chordToken, diagramWidth, 0, false);
+		if (!chordBox) {
+			return;
+		}
+		this.popper.appendChild(chordBox);
 
 		if (this.instance) {
 			this.instance.setProps({

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ export default class ChordSheetsPlugin extends Plugin implements IChordSheetsPlu
 			}
 		});
 
-		for (const instrument of Object.keys(ChordsDB) as Instrument[]) {
+		for (const instrument of [...Object.keys(ChordsDB), "piano"] as Instrument[]) {
 			this.addCommand({
 				id: `block-instrument-change-${instrument}`,
 				name: `Change instrument for the current chord block to ${instrument}`,

--- a/src/pianoChordRenderer.ts
+++ b/src/pianoChordRenderer.ts
@@ -1,0 +1,256 @@
+import {Chord, Note} from "tonal";
+import {ChordToken} from "./sheet-parsing/tokens";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const START_MIDI = 60; // C4
+const END_MIDI = 83;   // B5
+const NUM_OCTAVES = 2;
+const NUM_WHITE_KEYS = 7 * NUM_OCTAVES; // 14
+
+const SEMI_TO_WHITE: Record<number, number> = {0: 0, 2: 1, 4: 2, 5: 3, 7: 4, 9: 5, 11: 6};
+const SEMI_TO_BLACK: Record<number, number> = {1: 0, 3: 1, 6: 3, 8: 4, 10: 5};
+
+const inversionStore = new Map<string, number>();
+
+interface ActiveNote {
+	midi: number;
+	name: string;
+	isBass: boolean;
+}
+
+function svgEl(tag: string, attrs: Record<string, string | number> = {}): SVGElement {
+	const el = document.createElementNS(SVG_NS, tag);
+	for (const [key, value] of Object.entries(attrs)) {
+		el.setAttribute(key, String(value));
+	}
+	return el;
+}
+
+function getChordNotes(chordToken: ChordToken): string[] {
+	const chord = Chord.get(chordToken.chordSymbol.value);
+	if (!chord.tonic || chord.notes.length === 0) return [];
+
+	const notes = [...chord.notes];
+	if (chord.bass) {
+		const bc = Note.chroma(chord.bass);
+		if (bc !== undefined && !notes.some(n => Note.chroma(n) === bc)) {
+			notes.unshift(chord.bass);
+		}
+	}
+	return notes;
+}
+
+function computeInversion(noteNames: string[], inversionIndex: number): ActiveNote[] {
+	const notes: ActiveNote[] = [];
+	let octave = 4;
+	let prev = -1;
+
+	for (let i = 0; i < noteNames.length; i++) {
+		const name = noteNames[(inversionIndex + i) % noteNames.length];
+		let midi = Note.midi(name + octave);
+		while (midi !== null && midi <= prev) {
+			octave++;
+			midi = Note.midi(name + octave);
+		}
+		if (midi !== null) {
+			notes.push({midi, name, isBass: i === 0});
+			prev = midi;
+		}
+	}
+	return notes;
+}
+
+function whiteKeyIndex(midi: number): number | null {
+	const rel = midi - START_MIDI;
+	if (rel < 0 || rel >= NUM_OCTAVES * 12) return null;
+	const semi = rel % 12;
+	if (!(semi in SEMI_TO_WHITE)) return null;
+	return Math.floor(rel / 12) * 7 + SEMI_TO_WHITE[semi];
+}
+
+function blackKeyAfterWhite(midi: number): number | null {
+	const rel = midi - START_MIDI;
+	if (rel < 0 || rel >= NUM_OCTAVES * 12) return null;
+	const semi = rel % 12;
+	if (!(semi in SEMI_TO_BLACK)) return null;
+	return Math.floor(rel / 12) * 7 + SEMI_TO_BLACK[semi];
+}
+
+function noteCx(note: ActiveNote, wkw: number): number | null {
+	const wki = whiteKeyIndex(note.midi);
+	if (wki !== null) return wki * wkw + wkw / 2;
+	const aw = blackKeyAfterWhite(note.midi);
+	if (aw !== null) return (aw + 1) * wkw;
+	return null;
+}
+
+function renderPianoSvg(activeNotes: ActiveNote[], width: number): SVGSVGElement {
+	const wkw = width / NUM_WHITE_KEYS;
+	const wkh = width * 0.35;
+	const bkw = wkw * 0.6;
+	const bkh = wkh * 0.58;
+	const dotR = Math.max(wkw * 0.27, 1.5);
+	const kr = 1.5;
+	const labelH = Math.max(wkw * 0.75, 7);
+	const totalH = wkh + labelH + 1;
+
+	const activeMidi = new Set(activeNotes.map(n => n.midi));
+	const bassMidi = activeNotes.find(n => n.isBass)?.midi ?? -1;
+
+	const svg = svgEl("svg", {width, height: totalH, viewBox: `0 0 ${width} ${totalH}`}) as SVGSVGElement;
+	svg.classList.add("chord-sheet-piano-keyboard");
+
+	// White keys
+	const whiteSemis = [0, 2, 4, 5, 7, 9, 11];
+	for (let i = 0; i < NUM_WHITE_KEYS; i++) {
+		const oct = Math.floor(i / 7);
+		const midi = START_MIDI + oct * 12 + whiteSemis[i % 7];
+		const x = i * wkw;
+		const d = `M${x},0 L${x + wkw},0 L${x + wkw},${wkh - kr} Q${x + wkw},${wkh} ${x + wkw - kr},${wkh} L${x + kr},${wkh} Q${x},${wkh} ${x},${wkh - kr} Z`;
+		const path = svgEl("path", {d});
+		path.classList.add("chord-sheet-piano-wk");
+		if (activeMidi.has(midi)) path.classList.add("chord-sheet-piano-active");
+		svg.appendChild(path);
+	}
+
+	// White key separators
+	for (let i = 1; i < NUM_WHITE_KEYS; i++) {
+		const line = svgEl("line", {x1: i * wkw, y1: 0, x2: i * wkw, y2: wkh});
+		line.classList.add("chord-sheet-piano-sep");
+		svg.appendChild(line);
+	}
+
+	// Black keys
+	const blackDefs = [{s: 1, aw: 0}, {s: 3, aw: 1}, {s: 6, aw: 3}, {s: 8, aw: 4}, {s: 10, aw: 5}];
+	for (let oct = 0; oct < NUM_OCTAVES; oct++) {
+		for (const bk of blackDefs) {
+			const midi = START_MIDI + oct * 12 + bk.s;
+			const aw = oct * 7 + bk.aw;
+			const x = (aw + 1) * wkw - bkw / 2;
+			const d = `M${x},0 L${x + bkw},0 L${x + bkw},${bkh - kr} Q${x + bkw},${bkh} ${x + bkw - kr},${bkh} L${x + kr},${bkh} Q${x},${bkh} ${x},${bkh - kr} Z`;
+			const path = svgEl("path", {d});
+			path.classList.add("chord-sheet-piano-bk");
+			if (activeMidi.has(midi)) path.classList.add("chord-sheet-piano-active");
+			svg.appendChild(path);
+		}
+	}
+
+	// Dots + labels for each active note
+	for (const note of activeNotes) {
+		const isWhite = whiteKeyIndex(note.midi) !== null;
+		const inRange = note.midi >= START_MIDI && note.midi <= END_MIDI;
+		const cx = inRange ? noteCx(note, wkw) : null;
+
+		if (cx !== null) {
+			// Dot
+			const cy = isWhite ? wkh - wkw * 0.42 : bkh - bkw * 0.5;
+			const r = isWhite ? dotR : dotR * 0.85;
+			const dot = svgEl("circle", {cx, cy, r});
+			dot.classList.add("chord-sheet-piano-dot");
+			if (!isWhite) dot.classList.add("chord-sheet-piano-dot-on-black");
+			if (note.isBass) dot.classList.add("chord-sheet-piano-dot-bass");
+			svg.appendChild(dot);
+
+			// Note label below keyboard
+			const text = svgEl("text", {
+				x: cx,
+				y: wkh + labelH,
+				"text-anchor": "middle",
+				"font-size": Math.max(wkw * 0.65, 5.5),
+			});
+			text.textContent = note.name;
+			text.classList.add("chord-sheet-piano-label");
+			if (note.isBass) text.classList.add("chord-sheet-piano-label-bass");
+			svg.appendChild(text);
+		} else {
+			// Out-of-range indicator: arrow at the right edge
+			const edgeX = width - 2;
+			const text = svgEl("text", {
+				x: edgeX,
+				y: wkh + labelH,
+				"text-anchor": "end",
+				"font-size": Math.max(wkw * 0.55, 5),
+			});
+			text.textContent = `${note.name}\u2192`;
+			text.classList.add("chord-sheet-piano-label", "chord-sheet-piano-label-overflow");
+			svg.appendChild(text);
+		}
+	}
+
+	return svg;
+}
+
+function renderPianoDiagram(
+	containerEl: HTMLElement,
+	notes: ActiveNote[],
+	numPositions: number,
+	position: number,
+	chordName: string,
+	width: number,
+) {
+	const box = containerEl.querySelector(".chord-sheet-chord-box");
+	if (!box) return;
+	box.replaceChildren();
+
+	const nameEl = document.createElement("div");
+	nameEl.classList.add("chord-sheet-chord-name", "chord-sheet-chord-highlight");
+	nameEl.innerText = chordName;
+	box.appendChild(nameEl);
+
+	box.appendChild(renderPianoSvg(notes, width));
+
+	const posEl = containerEl.querySelector(".chord-sheet-position");
+	const prevBtn = containerEl.querySelector(".chord-sheet-btn-prev-position");
+	const nextBtn = containerEl.querySelector(".chord-sheet-btn-next-position");
+	if (posEl && prevBtn && nextBtn) {
+		posEl.textContent = `${position + 1}`;
+		nextBtn.classList.toggle("chord-sheet-pos-btn-enabled", position < numPositions - 1);
+		prevBtn.classList.toggle("chord-sheet-pos-btn-enabled", position > 0);
+	}
+}
+
+export function makePianoChordDiagram(chordToken: ChordToken, width = 100, showControls = true): HTMLElement | undefined {
+	const noteNames = getChordNotes(chordToken);
+	if (noteNames.length === 0) return undefined;
+
+	const chordSymbol = chordToken.chordSymbol.value;
+	const numPositions = noteNames.length;
+	const containerEl = document.createElement("div");
+	containerEl.classList.add("chord-sheet-chord-diagram");
+
+	const chordBox = document.createElement("div");
+	chordBox.classList.add("chord-sheet-chord-box");
+	containerEl.appendChild(chordBox);
+
+	let currentPosition = inversionStore.get(chordSymbol) ?? 0;
+	if (currentPosition >= numPositions) currentPosition = 0;
+
+	if (showControls && numPositions > 1) {
+		const chooser = Object.assign(document.createElement("div"), {className: "chord-sheet-position-chooser"});
+		const label = Object.assign(document.createElement("span"), {className: "chord-sheet-position-label"});
+		const prev = Object.assign(document.createElement("span"), {className: "chord-sheet-btn-prev-position", textContent: "<"});
+		const pos = Object.assign(document.createElement("span"), {className: "chord-sheet-position"});
+		const total = Object.assign(document.createElement("span"), {textContent: `/${numPositions}`});
+		label.append(pos, total);
+		chooser.append(prev, label, Object.assign(document.createElement("span"), {className: "chord-sheet-btn-next-position", textContent: ">"}));
+		containerEl.appendChild(chooser);
+
+		chooser.querySelector(".chord-sheet-btn-next-position")!.addEventListener("click", () => {
+			if (currentPosition < numPositions - 1) {
+				currentPosition++;
+				inversionStore.set(chordSymbol, currentPosition);
+				renderPianoDiagram(containerEl, computeInversion(noteNames, currentPosition), numPositions, currentPosition, chordSymbol, width);
+			}
+		});
+		chooser.querySelector(".chord-sheet-btn-prev-position")!.addEventListener("click", () => {
+			if (currentPosition > 0) {
+				currentPosition--;
+				inversionStore.set(chordSymbol, currentPosition);
+				renderPianoDiagram(containerEl, computeInversion(noteNames, currentPosition), numPositions, currentPosition, chordSymbol, width);
+			}
+		});
+	}
+
+	renderPianoDiagram(containerEl, computeInversion(noteNames, currentPosition), numPositions, currentPosition, chordSymbol, width);
+	return containerEl;
+}

--- a/styles.css
+++ b/styles.css
@@ -575,8 +575,124 @@ code.chord-sheet-chord-block-preview > .chord-sheet-section-header,
 }
 
 
+/* Piano Keyboard */
+
+.chord-sheet-piano-keyboard {
+	display: block;
+	margin-top: 2px;
+}
+
+.chord-sheet-piano-wk {
+	fill: #e8e8e8;
+	stroke: #aaa;
+	stroke-width: 0.5;
+}
+
+.theme-dark .chord-sheet-piano-wk {
+	fill: #d0d0d0;
+	stroke: #999;
+}
+
+.chord-sheet-piano-wk.chord-sheet-piano-active {
+	fill: color-mix(in srgb, var(--text-accent) 40%, #e8e8e8);
+}
+
+.theme-dark .chord-sheet-piano-wk.chord-sheet-piano-active {
+	fill: color-mix(in srgb, var(--text-accent) 50%, #d0d0d0);
+}
+
+.chord-sheet-piano-sep {
+	stroke: #aaa;
+	stroke-width: 0.5;
+}
+
+.theme-dark .chord-sheet-piano-sep {
+	stroke: #999;
+}
+
+.chord-sheet-piano-bk {
+	fill: #1a1a1a;
+	stroke: #000;
+	stroke-width: 0.3;
+}
+
+.theme-dark .chord-sheet-piano-bk {
+	fill: #111;
+}
+
+.chord-sheet-piano-bk.chord-sheet-piano-active {
+	fill: var(--text-accent);
+}
+
+.chord-sheet-piano-dot {
+	fill: var(--text-accent);
+}
+
+.chord-sheet-piano-dot-on-black {
+	fill: #fff;
+}
+
+.chord-sheet-piano-dot-bass {
+	stroke: #fff;
+	stroke-width: 1.2;
+}
+
+.chord-sheet-piano-dot-on-black.chord-sheet-piano-dot-bass {
+	fill: var(--text-accent);
+	stroke: #fff;
+	stroke-width: 1.2;
+}
+
+/* Note labels below keyboard */
+.chord-sheet-piano-label {
+	fill: var(--text-muted);
+	font-family: var(--font-monospace);
+}
+
+.chord-sheet-piano-label-bass {
+	fill: var(--text-accent);
+	font-weight: bold;
+}
+
+.chord-sheet-piano-label-overflow {
+	fill: var(--text-faint);
+	font-style: italic;
+}
+
+/* Print support */
+.print .chord-sheet-piano-wk.chord-sheet-piano-active {
+	fill: #ccc;
+}
+
+.print .chord-sheet-piano-dot,
+.print .chord-sheet-piano-dot-bass {
+	fill: #333;
+	stroke: none;
+}
+
+.print .chord-sheet-piano-dot-on-black {
+	fill: #fff;
+}
+
+.print .chord-sheet-piano-label {
+	fill: #555;
+}
+
+.print .chord-sheet-piano-label-bass {
+	fill: #000;
+}
+
+/* Piano diagram spacing and position chooser */
+.chord-sheet-chord-diagram:has(.chord-sheet-piano-keyboard) {
+	padding: 4px 6px;
+}
+
+.chord-sheet-chord-diagram:has(.chord-sheet-piano-keyboard) .chord-sheet-position-chooser {
+	margin-top: 2px;
+}
+
 /* Chord Boxes */
-.chord-sheet-chord-box svg {
+.chord-sheet-chord-box svg:not(.chord-sheet-piano-keyboard) {
 	margin-top: -10%;
 	margin-bottom: -5%;
 }
@@ -686,7 +802,7 @@ code.chord-sheet-chord-block-preview > .chord-sheet-section-header,
 		margin-bottom: 1rem;
 	}
 
-	.chord-sheet-chord-overview svg {
+	.chord-sheet-chord-overview svg:not(.chord-sheet-piano-keyboard) {
 		margin-top: -15%;
 	}
 }


### PR DESCRIPTION
## Summary

- Adds **piano** as a new instrument for chord diagrams (closes #39)
- 2-octave SVG keyboard (C4–B5) with highlighted chord tones computed via `tonal`
- Inversion selector (`< 1/3 >`) in chord overview, with global state so hover tooltips follow the selected inversion
- Slash chord bass notes supported and visually distinguished
- Note labels below the keyboard
- Theme-aware CSS (light/dark mode), print-friendly colors
- Out-of-range indicator for extended chords exceeding the 2-octave display

## Usage

Use ```` ```chords-piano ```` or select **Piano** from the instrument dropdown. Piano can also be set as the default instrument in settings.

## Files changed

- **New:** `src/pianoChordRenderer.ts` — SVG keyboard renderer + inversion logic
- **Modified:** `chordsUtils.ts`, `chordDiagrams.ts`, `chordBlocksStateField.ts`, `main.ts`, `chordSheetsSettingTab.ts`, `chordBlockToolsWidget.ts`, `chordTooltip.ts`, `chordBlockPostProcessorView.ts`, `styles.css`

## Test plan

- [ ] Create a note with ```` ```chords-piano ```` and verify chord diagrams render
- [ ] Switch instrument via dropdown and settings
- [ ] Test inversion selector in overview, verify tooltips follow
- [ ] Test slash chords (e.g. `C/G`)
- [ ] Test in both light and dark themes
- [ ] Test extended chords (9th, 13th) for out-of-range handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)